### PR TITLE
feat: Add Cloudflare cache purge on deployment

### DIFF
--- a/.github/workflows/cloudflare-purge.yml
+++ b/.github/workflows/cloudflare-purge.yml
@@ -1,0 +1,17 @@
+name: Purge Cloudflare Cache
+
+on:
+  push:
+    branches:
+      - main  # or 'master' depending on your default branch
+
+jobs:
+  purge_cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Purge Cloudflare Cache
+        run: |
+          curl -X POST "https://api.cloudflare.com/client/v4/zones/${{ secrets.CLOUDFLARE_ZONE_ID }}/purge_cache" \
+          -H "Authorization: Bearer ${{ secrets.CLOUDFLARE_API_TOKEN }}" \
+          -H "Content-Type: application/json" \
+          --data '{"purge_everything":true}'

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ A static website for the Computational Multiphase Physics Laboratory, built with
 4. **Deployment**
    - Typically managed via GitHub Pages when merged/pushed to the main branch
    - Local testing is recommended before committing changes
+   - Cloudflare cache is automatically purged on deployment via GitHub Actions
+     - Requires `CLOUDFLARE_ZONE_ID` and `CLOUDFLARE_API_TOKEN` secrets in repository settings
 
 ### Content Management
 


### PR DESCRIPTION
Adds a GitHub Actions workflow to automatically purge the Cloudflare
cache when changes are pushed to the main branch. This ensures that
the latest content is immediately available to users after deployment.