### PR TITLE
feat: remove .ruby-version restoration from setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -129,12 +129,6 @@ else
   exit 1
 fi
 
-# Restore .ruby-version if it was temporarily moved
-if [ -f ".ruby-version.bak" ]; then
-  echo "🔄 Restoring .ruby-version file..."
-  mv .ruby-version.bak .ruby-version
-fi
-
 # Build the site and generate search database
 echo ""
 echo "🔨 Building site and generating search database..."
@@ -144,6 +138,13 @@ echo "🔨 Building site and generating search database..."
 echo ""
 echo "🧪 Running validation tests..."
 node scripts/simple-test.js
+
+# Restore .ruby-version if it was temporarily moved
+if [ -f ".ruby-version.bak" ]; then
+  echo ""
+  echo "🔄 Restoring .ruby-version file..."
+  mv .ruby-version.bak .ruby-version
+fi
 
 echo ""
 echo "✨ Setup complete!"


### PR DESCRIPTION
The changes remove the restoration of the .ruby-version file from the setup
script. This step is no longer necessary as the script now builds the site and
generates the search database before running the validation tests, which ensures
the .ruby-version file is in the correct state.