### PR TITLE
feat: Upgrade Node.js version to 20 in weekly tests

### DIFF
--- a/.github/workflows/weekly-tests.yml
+++ b/.github/workflows/weekly-tests.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
           cache: "npm"
 
       - name: Install dependencies


### PR DESCRIPTION
Upgrades the Node.js version used in the weekly tests workflow
from 18 to 20. This ensures the codebase is tested against the
latest stable version of Node.js, providing better compatibility
and security.