### PR TITLE
Opt Pages deploy into Node 24

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -54,6 +54,8 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- Opt the GitHub Pages deploy job into Node 24 to silence the Node 20 deprecation warning surfaced by Actions.
- Scope the change to the deploy job only so the build job stays unchanged.

## Changes
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to the `deploy` job in `.github/workflows/jekyll.yml`.
- Keep the change narrow to the Pages deploy step that emitted the warning on run `24437089067`.

## Testing
- Ran `git diff --check`.
- Commit hook formatting completed cleanly.
