### PR TITLE
fix: correct Watchout typo and serve about.html at /about/

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,3 +1,7 @@
+---
+permalink: /about/
+sitemap: false
+---
 <!DOCTYPE html>
 <html>
 <head>

--- a/aboutCoMPhy.md
+++ b/aboutCoMPhy.md
@@ -18,7 +18,7 @@ We investigate various viscous free-surface flows including inertial contact lin
 
 ## Commitment to Open Science
 
-Open exchange of ideas drives our progress. We share our codes from the earliest stages of development, embracing transparent research practices to foster collaboration and reproducibility. We welcome inquiries and partnerships from the broader scientific community. Watchout for [![GitHub](https://img.shields.io/badge/GitHub-100000?style=flat-square&logo=github&logoColor=white)](https://github.com/comphy-lab) and [<i class="fa-brands fa-github" style="font-size: 1.5em; color: black;"></i>](https://github.com/comphy-lab "Visit our GitHub organization") on this website to interact with our codes.
+Open exchange of ideas drives our progress. We share our codes from the earliest stages of development, embracing transparent research practices to foster collaboration and reproducibility. We welcome inquiries and partnerships from the broader scientific community. Watch out for [![GitHub](https://img.shields.io/badge/GitHub-100000?style=flat-square&logo=github&logoColor=white)](https://github.com/comphy-lab) and [<i class="fa-brands fa-github" style="font-size: 1.5em; color: black;"></i>](https://github.com/comphy-lab "Visit our GitHub organization") on this website to interact with our codes.
 
 Feel free to contact us for discussions about our work or anything else related to fluid physics. Nothing is more exhilarating than a healthy scientific discussion.
 


### PR DESCRIPTION
## Summary

- Fixes a typo on the homepage open-science blurb (`Watchout for` → `Watch out for`) in `aboutCoMPhy.md`.
- Adds `permalink: /about/` front matter to `about.html` so `https://comphy-lab.org/about/` resolves to the existing meta-refresh stub (currently 404s for the trailing-slash variant). `sitemap: false` keeps the redirect stub out of the sitemap.

Both bugs surfaced while browsing the live site — nothing in the nav links directly to `/about/`, but the trailing-slash URL can still be hit from search results or typed entry.

## Test plan

- [ ] `bundle exec jekyll serve` locally and confirm `/about/` 302s / meta-refreshes to `/#about`.
- [ ] Visually check the Open Science paragraph on the homepage renders correctly after the typo fix.
- [ ] Confirm `/about` (no slash) still works as before.

## Notes

- The surrounding sentence on the open-science block is still a little awkward even post-typo (*"Watch out for \[badge\] and \[icon\] on this website to interact with our codes"*). Didn't rewrite unprompted — happy to follow up if wanted.