### PR TITLE
Bump addressable to 2.9.0 (CVE-2026-35611)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     bigdecimal (3.1.9)
     colorator (1.1.0)
     concurrent-ruby (1.3.4)


### PR DESCRIPTION
## Summary

- Lockfile bump for `addressable` from 2.8.7 → 2.9.0 to close GHSA #32 / CVE-2026-35611 (ReDoS in URI templates).
- Two-line Gemfile.lock change; the `Gemfile` constraint (`~> 2.4`, set by Jekyll) is unchanged.
- `public_suffix` runtime bound widens from `< 7.0` to `< 8.0` in 2.9.0; the already-pinned `public_suffix 6.0.1` still satisfies both bounds, so no transitive bump is needed.

Lockfile was hand-edited because the repo pins Bundler 2.5.23 / Ruby 3.2.2 and a clean `bundle update` requires those. CI will run the full `bundle install` and validate.

## Test plan

- [ ] `Jekyll site CI` build job passes (this exercises `bundle install` against the new lockfile)
- [ ] `Maintenance Regression Checks` passes
- [ ] No other workflows fail
- [ ] Confirm dependabot alert #32 closes once the PR merges