### PR TITLE
Pad table separator rows for markdownlint MD060

### DIFF
--- a/_org_profile/README.md
+++ b/_org_profile/README.md
@@ -139,7 +139,7 @@ We are a computational physics research group based at the **Department of Physi
 <div align="center">
 
 | Project | Description | Technologies | Status |
-|---------|-------------|--------------|--------|
+| --- | --- | --- | --- |
 | 🌊 [**Bubble Dynamics**](https://github.com/comphy-lab) | Worthington jet formation from bursting bubbles | Basilisk C, MPI | ![Active](https://img.shields.io/badge/Active-green?style=flat-square) |
 | 💧 [**Droplet Physics**](https://github.com/comphy-lab) | Non-Newtonian droplet impact phenomena | OpenFOAM, Python | ![Active](https://img.shields.io/badge/Active-green?style=flat-square) |
 | 🔄 [**Viscoelastic Flows**](https://github.com/comphy-lab) | Complex fluid behavior in confined geometries | Basilisk C, Julia | ![Development](https://img.shields.io/badge/Development-yellow?style=flat-square) |

--- a/fix-summary.md
+++ b/fix-summary.md
@@ -93,7 +93,7 @@ to `tests/deploy-script-regression.sh`:
 ## Test Results
 
 | Suite | Result |
-|---|---|
+| --- | --- |
 | `jest` (all 9 suites, 51 tests) | **PASS** |
 | `tests/deploy-script-regression.sh` (9 scenarios) | **PASS** |
 | `scripts/validate-content-rules.sh` | **PASS** |


### PR DESCRIPTION
## Summary

- Two markdown tables (`_org_profile/README.md:142`, `fix-summary.md:96`) used the compact `|---|---|` separator-row form.
- Newer markdownlint releases enable MD060/table-column-style by default, which wants `| --- | --- |` for the project's effective config.
- CI's pinned `markdownlint-cli2@0.18.1` doesn't currently flag this, but a local newer install does — so this is a latent failure waiting on a tooling bump. Padding now makes the repo robust against both today's CI version and any future bump.

## Test plan

- [ ] `Teaching Content Checks` workflow passes (markdownlint runs against the full repo via the config's `**/*.md` glob)