### PR TITLE
Fix footer maintainer links

### DIFF
--- a/_includes/footer-v2.html
+++ b/_includes/footer-v2.html
@@ -58,8 +58,8 @@
     <div class="c-footer__legal">
       <div>
         © 2019–{{ 'now' | date: '%Y' }} CoMPhy Lab · Maintained by
-        <a href="/VatsalSy">V. Sanjay</a> and
-        <a href="/comphy-bot">Worthy</a>
+        <a href="https://www.durham.ac.uk/staff/vatsal-sanjay/" target="_blank" rel="noopener noreferrer">V. Sanjay</a> and
+        <a href="https://github.com/comphy-lab" target="_blank" rel="noopener noreferrer">Worthy</a>
       </div>
       <div>
         <a href="https://github.com/comphy-lab/comphy-lab.github.io" target="_blank" rel="noopener noreferrer">Edit on GitHub</a>


### PR DESCRIPTION
## Summary

Replace the broken footer maintainer-credit routes (`/VatsalSy` and `/comphy-bot`) with live external destinations so the v2 footer no longer emits 404s.

## Evidence

- Copilot flagged the broken footer links in PR #86 review comments for `_includes/footer-v2.html`.
- The current footer rendered `/VatsalSy` and `/comphy-bot`, but neither route exists in the repo.

## Change

- Link V. Sanjay to the Durham staff page.
- Link Worthy to the CoMPhy GitHub org.

## Validation

- `git diff --check` passes.
