### PR TITLE
Fix SoftComp news URL typo

### DIFF
--- a/News.md
+++ b/News.md
@@ -2,7 +2,7 @@
 
 ### May
 
-- [<strong>Dixit, A. K.</strong>, Zhao, C., Zaleski, S., Lohse, D., & <strong>Sanjay, V.</strong> Holes in Sheets: Double-Threshold Rupture of Draining Liquid Films.</strong> Featured on <a href="https://eu-softcomp.net/tiniy-defects-big-consequences/">SoftComp Network News</a>: "Tiny Defects, Big Consequences: Why Micron-thick Films Tear Before Molecular Forces Matter." Phys. Rev. Lett., 136, 084001 (2026).](/research#22)
+- [<strong>Dixit, A. K.</strong>, Zhao, C., Zaleski, S., Lohse, D., & <strong>Sanjay, V.</strong> Holes in Sheets: Double-Threshold Rupture of Draining Liquid Films.</strong> Featured on <a href="https://eu-softcomp.net/tiny-defects-big-consequences/">SoftComp Network News</a>: "Tiny Defects, Big Consequences: Why Micron-thick Films Tear Before Molecular Forces Matter." Phys. Rev. Lett., 136, 084001 (2026).](/research#22)
 
 ### March
 

--- a/_data/news.yml
+++ b/_data/news.yml
@@ -13,7 +13,6 @@
 #   action_label + action_href — the right-side button.
 
 items:
-
   # ===================== 2026 =====================
 
   - date: "2026-05-28"
@@ -38,7 +37,7 @@ items:
       films—imperfections trigger rupture long before molecular forces matter.
     thumb: /assets/images/research/holey-sheets.png
     action_label: "Read feature"
-    action_href: "https://eu-softcomp.net/tiniy-defects-big-consequences/"
+    action_href: "https://eu-softcomp.net/tiny-defects-big-consequences/"
 
   - date: "2026-05-12"
     kind: paper


### PR DESCRIPTION
Correct the Tiny Defects SoftComp link in the structured news feed and the legacy News.md mirror.

Evidence: the checked-in files still pointed at `tiniy-defects-big-consequences`, despite the earlier commit message claiming the typo was fixed.

Validation: `git diff --check` and the repo's staged-file hooks passed during commit.