### PR TITLE
Align rebuild workflow Ruby toolchain

### DIFF
--- a/.github/workflows/rebuild-on-search-update.yml
+++ b/.github/workflows/rebuild-on-search-update.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.2.2"
+          bundler: "2.5.23"
           bundler-cache: true
 
       - name: Build site and search database


### PR DESCRIPTION
## Summary
- Align Ruby setup in the search-db rebuild workflow with the main Jekyll CI toolchain.

## Changes
- Update `.github/workflows/rebuild-on-search-update.yml` to pin `ruby-version` to `3.2.2`.
- Add explicit `bundler` version `2.5.23` in the same workflow for consistency with `.github/workflows/jekyll.yml`.

## Testing
- Not run (workflow-level change only; no local runtime validation requested).
