### PR TITLE
Harden update-search workflow to prevent GitHub App token leakage

### DIFF
--- a/.github/workflows/update-search.yml
+++ b/.github/workflows/update-search.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for proper git operations
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Clone comphy-search repository
         run: |
@@ -41,7 +42,10 @@ jobs:
 
       - name: Copy search database
         run: |
-          cp comphy-search/search_db.json assets/js/search_db.json
+          test -f comphy-search/search_db.json
+          test ! -L comphy-search/search_db.json
+          jq empty comphy-search/search_db.json
+          cp --no-dereference comphy-search/search_db.json assets/js/search_db.json
 
       - name: Commit and push changes with app token
         env:
@@ -59,5 +63,7 @@ jobs:
           else
             git commit -m "Update search database from comphy-search repository"
             git log -1 --pretty=fuller
-            git push origin HEAD:main
+            git push \
+              "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+              HEAD:main
           fi


### PR DESCRIPTION
### Motivation

- A workflow step created a GitHub App token before `actions/checkout` and relied on the checkout to persist credentials, which allowed a malicious symlinked `search_db.json` from an external repo to dereference and leak the token into a committed file. 
- The change closes this credential-exposure path by ensuring the short-lived App token is not persisted and the imported file is validated before copying.

### Description

- Disable credential persistence by adding `persist-credentials: false` to the `actions/checkout` step. 
- Validate the imported file by checking it exists with `test -f`, asserting it is not a symlink with `test ! -L`, and confirming it is valid JSON with `jq empty` before copying. 
- Use `cp --no-dereference` to avoid following symlinks when copying `comphy-search/search_db.json` into `assets/js/search_db.json`. 
- Push using an explicit HTTPS URL containing the short-lived App token at push time (`https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git`) instead of relying on credentials persisted by checkout.

### Testing

- Ran repository linters with `./scripts/lint-check.sh` and the script completed successfully. 
- Performed a local symlink-regression simulation (creating a symlinked `search_db.json` and confirming the workflow steps block the copy); the simulation output showed the symlinked file was blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42239fcf8c832aa60ef8f8047ba20b)