### PR TITLE
Address Python course review feedback

### DIFF
--- a/_teaching/index.md
+++ b/_teaching/index.md
@@ -14,16 +14,16 @@ description: >-
     <div class="course-card__content">
       <h3 class="course-card__title">CoMPhy Python 101</h3>
       <div class="course-card__meta">
-        <i class="fa-solid fa-globe"></i> Open online course
+        <i class="fa-solid fa-globe" aria-hidden="true"></i> Open online course
       </div>
       <div class="course-card__meta">
-        <i class="fa-solid fa-route"></i> Self-paced · quick and full routes
+        <i class="fa-solid fa-route" aria-hidden="true"></i> Self-paced · quick and full routes
       </div>
       <p class="course-card__desc">
         Mechanism-first Python onboarding: turn a physical question into
         trustworthy computation and reproducible evidence.
       </p>
-      <a href="/comphy-python101/" class="course-card__link">Start Course</a>
+      <a href="https://comphy-lab.org/comphy-python101/" class="course-card__link">Start Course</a>
     </div>
   </div>
 


### PR DESCRIPTION
## Summary

Follow-up to #97:

- mark both decorative course-card icons as hidden from assistive technology
- use the explicit published course URL to make the cross-repository Pages ownership clear

The two dead-link comments on #97 were duplicates and the route was already live as a separate project Pages deployment; the absolute URL removes the ambiguity for future static review.

## Verification

- `npm test -- --runInBand` — 12 suites, 77 tests passed
- Prettier check — passed
- Markdown lint — 0 errors
- `https://comphy-lab.org/comphy-python101/` — HTTP 200