### PR TITLE
Add in-house contact card

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -93,6 +93,9 @@
   {% if page.layout == "teaching" or page.layout == "teaching-course" or page.body_class contains "teaching-v2" %}
   <link rel="stylesheet" href="/assets/css/teaching.css">
   {% endif %}
+  {% if page.body_class contains "contact-card-page" %}
+  <link rel="stylesheet" href="/assets/css/contact-card.css">
+  {% endif %}
   
   <!-- Structured Data for SEO -->
   <script type="application/ld+json">
@@ -131,6 +134,9 @@
   <script defer src="https://cdn.jsdelivr.net/npm/dompurify@3.0.5/dist/purify.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/fuse.js@6.6.2"></script>
   <script defer src="/assets/js/main.js"></script>
+  {% if page.body_class contains "contact-card-page" %}
+  <script defer src="/assets/js/contact-card.js"></script>
+  {% endif %}
   {% if page.layout == "teaching" %}
   <script defer src="/assets/js/teaching.js"></script>
   {% endif %}

--- a/assets/contact/vatsal-sanjay.vcf
+++ b/assets/contact/vatsal-sanjay.vcf
@@ -1,0 +1,15 @@
+BEGIN:VCARD
+VERSION:3.0
+N:Sanjay;Vatsal;;Dr.;
+FN:Dr. Vatsal Sanjay
+ORG:Durham University;Department of Physics;CoMPhy Lab
+TITLE:Assistant Professor
+EMAIL;TYPE=INTERNET,WORK:vatsal.sanjay@durham.ac.uk
+ADR;TYPE=WORK:;;Ph255\, Wolfendale Wing\, Rochester Building\, South Road;Durham;;DH1 3LE;United Kingdom
+URL:https://comphy-lab.org
+URL;TYPE=WORK:https://www.durham.ac.uk/staff/vatsal-sanjay/
+X-SOCIALPROFILE;TYPE=github:https://github.com/comphy-lab
+X-SOCIALPROFILE;TYPE=linkedin:https://www.linkedin.com/in/vatsalsanjay/
+X-SOCIALPROFILE;TYPE=youtube:https://www.youtube.com/c/VatsalSanjay
+NOTE:Principal Investigator\, Computational Multiphase Physics Lab
+END:VCARD

--- a/assets/css/contact-card.css
+++ b/assets/css/contact-card.css
@@ -247,15 +247,32 @@
 .contact-card__socials {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--s-2) var(--s-4);
+  gap: var(--s-2);
   margin-top: var(--s-3);
 }
 
+/* Social profiles as btn-ghost pills, not bare text links. */
 .contact-card__detail .contact-card__socials a {
-  color: var(--c-accent-teal);
-  font-family: var(--t-mono);
-  font-size: 0.74rem;
+  display: inline-flex;
+  align-items: center;
+  padding: var(--s-2) var(--s-4);
+  border: 1px solid var(--c-border-strong);
+  border-radius: var(--r-pill);
+  color: var(--fg-1);
+  font-family: var(--t-sans);
+  font-size: var(--t-small);
   font-weight: var(--t-weight-med);
+  transition:
+    color var(--dur-fast) var(--ease),
+    border-color var(--dur-fast) var(--ease),
+    background var(--dur-fast) var(--ease);
+}
+
+.contact-card__detail .contact-card__socials a:hover,
+.contact-card__detail .contact-card__socials a:focus-visible {
+  border-color: var(--c-accent-teal);
+  color: var(--c-accent-teal);
+  background: color-mix(in srgb, var(--c-accent-teal) 8%, transparent);
 }
 
 .contact-card__footer {
@@ -338,8 +355,19 @@
 :root[data-theme="dark"] .contact-card__quick-actions a:hover,
 :root[data-theme="dark"] .contact-card__quick-actions a:focus-visible,
 :root[data-theme="dark"] .contact-card__detail a:hover,
-:root[data-theme="dark"] .contact-card__text-link,
+:root[data-theme="dark"] .contact-card__text-link {
+  color: var(--c-accent-teal);
+}
+
 :root[data-theme="dark"] .contact-card__detail .contact-card__socials a {
+  color: var(--fg-1);
+}
+
+:root[data-theme="dark"] .contact-card__detail .contact-card__socials a:hover,
+:root[data-theme="dark"]
+  .contact-card__detail
+  .contact-card__socials
+  a:focus-visible {
   color: var(--c-accent-teal);
 }
 

--- a/assets/css/contact-card.css
+++ b/assets/css/contact-card.css
@@ -1,121 +1,51 @@
-/* Contact card: a focused, mobile-first v2 page. */
-
-.contact-card-page {
-  --contact-card-light: #fffdf9;
-  --contact-card-hero: #254c4a;
-}
-
-.contact-card-page .s-header {
-  position: absolute;
-}
-
-.contact-card-page .s-header__logo,
-.contact-card-page .s-header__menu-toggle {
-  filter: drop-shadow(
-    0 2px 8px color-mix(in srgb, var(--fg-strong) 12%, transparent)
-  );
-}
+/* Contact card: a focused, mobile-first v2 page.
+   Sits on bare paper + grid like every v2 surface; all colour
+   lives inside the card (design-system rule: no page washes). */
 
 .contact-card-page .c-footer {
   margin-top: 0;
 }
 
 .contact-card {
-  isolation: isolate;
   min-height: 100svh;
   padding: clamp(7rem, 12vw, 9rem) var(--s-4) var(--s-8);
-  position: relative;
   display: grid;
   place-items: start center;
-  overflow: hidden;
 }
 
-.contact-card:before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: -2;
-  background:
-    linear-gradient(
-      135deg,
-      color-mix(in srgb, var(--c-accent-red) 10%, transparent),
-      transparent 34%
-    ),
-    linear-gradient(
-      315deg,
-      color-mix(in srgb, var(--c-accent-violet) 9%, transparent),
-      transparent 38%
-    );
-}
-
-.contact-card__glow {
-  position: absolute;
-  z-index: -1;
-  width: 22rem;
-  aspect-ratio: 1;
-  border-radius: 50%;
-  filter: blur(80px);
-  opacity: 0.14;
-  pointer-events: none;
-}
-
-.contact-card__glow--one {
-  top: 4rem;
-  left: -11rem;
-  background: var(--c-accent-red);
-}
-
-.contact-card__glow--two {
-  right: -12rem;
-  bottom: 12rem;
-  background: var(--c-accent-violet);
-}
-
+/* Panel recipe: translucent glass over paper, 28-px radius. */
 .contact-card__sheet {
   width: min(100%, 43rem);
   overflow: hidden;
-  border: 1px solid var(--c-border-strong);
+  border: 1px solid var(--c-border);
   border-radius: var(--r-lg);
-  background: color-mix(in srgb, var(--c-surface-strong) 94%, transparent);
-  box-shadow: var(--shadow-lg);
-  backdrop-filter: blur(18px);
+  background: var(--c-surface-glass);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  box-shadow: var(--shadow-soft);
 }
 
+/* Identity bed: teal-tinted paper, same mix as the PI member
+   card in the design system (.member--pi). */
 .contact-card__identity {
-  position: relative;
   min-height: 23rem;
   display: grid;
   grid-template-columns: minmax(9rem, 0.8fr) minmax(13rem, 1.2fr);
   grid-template-rows: auto 1fr;
   gap: var(--s-5);
   padding: var(--s-5);
-  color: var(--contact-card-light);
-  background: var(--contact-card-hero);
-}
-
-.contact-card__identity:after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background:
-    radial-gradient(
-      circle at 68% 18%,
-      rgba(255, 255, 255, 0.14),
-      transparent 30%
-    ),
-    linear-gradient(145deg, transparent 54%, rgba(0, 0, 0, 0.17));
+  border-bottom: 1px solid var(--c-border);
+  background: color-mix(in srgb, var(--c-accent-teal) 12%, var(--c-paper-tint));
 }
 
 .contact-card__brand {
-  z-index: 1;
   grid-column: 1 / -1;
   justify-self: start;
   display: inline-flex;
   align-items: center;
   gap: var(--s-2);
   border: 0;
-  color: inherit;
+  color: var(--fg-2);
   font-family: var(--t-mono);
   font-size: var(--t-eyebrow);
   font-weight: var(--t-weight-semi);
@@ -123,35 +53,33 @@
   text-transform: uppercase;
 }
 
-.contact-card__brand:hover {
-  color: var(--contact-card-light);
+.contact-card__brand:hover,
+.contact-card__brand:focus-visible {
+  color: var(--c-accent-teal);
 }
 
 .contact-card__brand img {
   width: 2.25rem;
   height: 2.25rem;
   object-fit: contain;
-  filter: brightness(0) invert(1);
 }
 
 .contact-card__portrait-wrap {
-  z-index: 1;
   align-self: end;
   margin: 0;
   aspect-ratio: 4 / 5;
   overflow: hidden;
-  border: 1px solid rgba(255, 255, 255, 0.28);
+  border: 1px solid var(--c-border-strong);
   border-radius: 8rem 8rem var(--r-md) var(--r-md);
-  box-shadow: 0 1.5rem 3.5rem rgba(0, 0, 0, 0.24);
-  transform: rotate(-1.5deg);
+  box-shadow: var(--shadow-md);
   transition:
     transform 480ms var(--ease),
     box-shadow 480ms var(--ease);
 }
 
 .contact-card__portrait-wrap:hover {
-  transform: rotate(0deg) translateY(-0.25rem);
-  box-shadow: 0 1.8rem 4rem rgba(0, 0, 0, 0.29);
+  transform: translateY(-0.25rem);
+  box-shadow: var(--shadow-soft);
 }
 
 .contact-card__portrait {
@@ -162,28 +90,27 @@
 }
 
 .contact-card__heading {
-  z-index: 1;
   align-self: end;
   padding-bottom: var(--s-3);
 }
 
+/* .eyebrow keeps its bridge colours: brand purple, #c09bc4 dark. */
 .contact-card__heading .eyebrow {
   margin: 0 0 var(--s-2);
-  color: rgba(255, 255, 255, 0.72);
 }
 
 .contact-card__heading h1 {
   margin: 0;
-  color: var(--contact-card-light);
-  font-size: clamp(2.45rem, 8vw, 4.8rem);
-  line-height: 0.94;
-  letter-spacing: -0.045em;
+  color: var(--fg-strong);
+  font-size: clamp(2.45rem, 8vw, 4.25rem);
+  line-height: 0.98;
+  letter-spacing: -0.03em;
 }
 
 .contact-card__role {
   max-width: 24ch;
   margin: var(--s-4) 0 0;
-  color: rgba(255, 255, 255, 0.78);
+  color: var(--fg-2);
   font-size: var(--t-small);
   line-height: 1.45;
 }
@@ -294,6 +221,7 @@
   font-weight: var(--t-weight-semi);
 }
 
+/* Copy button: btn-ghost recipe, mono label. */
 .contact-card__copy {
   align-self: center;
   padding: var(--s-2) var(--s-3);
@@ -356,17 +284,34 @@
     background var(--dur) var(--ease);
 }
 
+/* Primary action: .btn recipe — solid teal pill. */
 .contact-card__save {
   border: 1px solid var(--c-accent-teal);
   color: var(--c-accent-teal-fg);
   background: var(--c-accent-teal);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--shadow-sm);
 }
 
+.contact-card__save:hover,
+.contact-card__save:focus-visible {
+  border-color: var(--c-accent-teal-hover);
+  border-bottom-color: var(--c-accent-teal-hover);
+  color: var(--c-accent-teal-fg);
+  background: var(--c-accent-teal-hover);
+}
+
+/* Secondary action: .btn-ghost recipe. */
 .contact-card__share {
   border: 1px solid var(--c-border-strong);
-  color: var(--fg-strong);
-  background: var(--c-surface-strong);
+  color: var(--fg-1);
+  background: transparent;
+}
+
+.contact-card__share:hover,
+.contact-card__share:focus-visible {
+  border-color: var(--c-accent-teal);
+  color: var(--c-accent-teal);
+  background: color-mix(in srgb, var(--c-accent-teal) 8%, transparent);
 }
 
 .contact-card__save:hover,
@@ -374,14 +319,44 @@
 .contact-card__share:hover,
 .contact-card__share:focus-visible {
   transform: translateY(-2px);
-  box-shadow: var(--shadow-soft);
 }
 
-.contact-card__save:hover,
-.contact-card__save:focus-visible {
-  border-bottom-color: var(--c-accent-teal);
-  color: var(--c-accent-teal-fg);
-  background: var(--c-accent-teal-hover);
+/* The global dark link rule (:root[data-theme="dark"] a, #8fb8ff)
+   out-specifies single-class selectors; restate card link colours
+   under the dark scope so nothing leaks blue. */
+:root[data-theme="dark"] .contact-card__brand {
+  color: var(--fg-2);
+}
+
+:root[data-theme="dark"] .contact-card__quick-actions a,
+:root[data-theme="dark"] .contact-card__detail a:not(.contact-card__text-link) {
+  color: var(--fg-strong);
+}
+
+:root[data-theme="dark"] .contact-card__brand:hover,
+:root[data-theme="dark"] .contact-card__brand:focus-visible,
+:root[data-theme="dark"] .contact-card__quick-actions a:hover,
+:root[data-theme="dark"] .contact-card__quick-actions a:focus-visible,
+:root[data-theme="dark"] .contact-card__detail a:hover,
+:root[data-theme="dark"] .contact-card__text-link,
+:root[data-theme="dark"] .contact-card__detail .contact-card__socials a {
+  color: var(--c-accent-teal);
+}
+
+/* Dark teal is light (#6ac2bd): dark ink on it, as tokens' .btn. */
+:root[data-theme="dark"] .contact-card__save,
+:root[data-theme="dark"] .contact-card__save:hover,
+:root[data-theme="dark"] .contact-card__save:focus-visible {
+  color: #0c1a19;
+}
+
+:root[data-theme="dark"] .contact-card__share {
+  color: var(--fg-1);
+}
+
+:root[data-theme="dark"] .contact-card__share:hover,
+:root[data-theme="dark"] .contact-card__share:focus-visible {
+  color: var(--c-accent-teal);
 }
 
 .contact-card__status {
@@ -442,7 +417,6 @@
     justify-self: center;
     border-radius: 8rem;
     aspect-ratio: 1;
-    transform: rotate(-1deg);
   }
 
   .contact-card__heading {

--- a/assets/css/contact-card.css
+++ b/assets/css/contact-card.css
@@ -1,0 +1,489 @@
+/* Contact card: a focused, mobile-first v2 page. */
+
+.contact-card-page {
+  --contact-card-light: #fffdf9;
+  --contact-card-hero: #254c4a;
+}
+
+.contact-card-page .s-header {
+  position: absolute;
+}
+
+.contact-card-page .s-header__logo,
+.contact-card-page .s-header__menu-toggle {
+  filter: drop-shadow(
+    0 2px 8px color-mix(in srgb, var(--fg-strong) 12%, transparent)
+  );
+}
+
+.contact-card-page .s-footer-v2 {
+  margin-top: 0;
+}
+
+.contact-card {
+  isolation: isolate;
+  min-height: 100svh;
+  padding: clamp(7rem, 12vw, 9rem) var(--s-4) var(--s-8);
+  position: relative;
+  display: grid;
+  place-items: start center;
+  overflow: hidden;
+}
+
+.contact-card:before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -2;
+  background:
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--c-accent-red) 10%, transparent),
+      transparent 34%
+    ),
+    linear-gradient(
+      315deg,
+      color-mix(in srgb, var(--c-accent-violet) 9%, transparent),
+      transparent 38%
+    );
+}
+
+.contact-card__glow {
+  position: absolute;
+  z-index: -1;
+  width: 22rem;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  filter: blur(80px);
+  opacity: 0.14;
+  pointer-events: none;
+}
+
+.contact-card__glow--one {
+  top: 4rem;
+  left: -11rem;
+  background: var(--c-accent-red);
+}
+
+.contact-card__glow--two {
+  right: -12rem;
+  bottom: 12rem;
+  background: var(--c-accent-violet);
+}
+
+.contact-card__sheet {
+  width: min(100%, 43rem);
+  overflow: hidden;
+  border: 1px solid var(--c-border-strong);
+  border-radius: var(--r-lg);
+  background: color-mix(in srgb, var(--c-surface-strong) 94%, transparent);
+  box-shadow: var(--shadow-lg);
+  backdrop-filter: blur(18px);
+}
+
+.contact-card__identity {
+  position: relative;
+  min-height: 23rem;
+  display: grid;
+  grid-template-columns: minmax(9rem, 0.8fr) minmax(13rem, 1.2fr);
+  grid-template-rows: auto 1fr;
+  gap: var(--s-5);
+  padding: var(--s-5);
+  color: var(--contact-card-light);
+  background: var(--contact-card-hero);
+}
+
+.contact-card__identity:after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(
+      circle at 68% 18%,
+      rgba(255, 255, 255, 0.14),
+      transparent 30%
+    ),
+    linear-gradient(145deg, transparent 54%, rgba(0, 0, 0, 0.17));
+}
+
+.contact-card__brand {
+  z-index: 1;
+  grid-column: 1 / -1;
+  justify-self: start;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-2);
+  border: 0;
+  color: inherit;
+  font-family: var(--t-mono);
+  font-size: var(--t-eyebrow);
+  font-weight: var(--t-weight-semi);
+  letter-spacing: var(--t-track-wide);
+  text-transform: uppercase;
+}
+
+.contact-card__brand:hover {
+  color: var(--contact-card-light);
+}
+
+.contact-card__brand img {
+  width: 2.25rem;
+  height: 2.25rem;
+  object-fit: contain;
+  filter: brightness(0) invert(1);
+}
+
+.contact-card__portrait-wrap {
+  z-index: 1;
+  align-self: end;
+  margin: 0;
+  aspect-ratio: 4 / 5;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 8rem 8rem var(--r-md) var(--r-md);
+  box-shadow: 0 1.5rem 3.5rem rgba(0, 0, 0, 0.24);
+  transform: rotate(-1.5deg);
+  transition:
+    transform 480ms var(--ease),
+    box-shadow 480ms var(--ease);
+}
+
+.contact-card__portrait-wrap:hover {
+  transform: rotate(0deg) translateY(-0.25rem);
+  box-shadow: 0 1.8rem 4rem rgba(0, 0, 0, 0.29);
+}
+
+.contact-card__portrait {
+  width: 100%;
+  height: 100%;
+  display: block;
+  object-fit: cover;
+}
+
+.contact-card__heading {
+  z-index: 1;
+  align-self: end;
+  padding-bottom: var(--s-3);
+}
+
+.contact-card__heading .eyebrow {
+  margin: 0 0 var(--s-2);
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.contact-card__heading h1 {
+  margin: 0;
+  color: var(--contact-card-light);
+  font-size: clamp(2.45rem, 8vw, 4.8rem);
+  line-height: 0.94;
+  letter-spacing: -0.045em;
+}
+
+.contact-card__role {
+  max-width: 24ch;
+  margin: var(--s-4) 0 0;
+  color: rgba(255, 255, 255, 0.78);
+  font-size: var(--t-small);
+  line-height: 1.45;
+}
+
+.contact-card__quick-actions {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  border-bottom: 1px solid var(--c-border);
+}
+
+.contact-card__quick-actions a {
+  min-height: 4.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--s-3);
+  border: 0;
+  color: var(--fg-strong);
+  font-size: var(--t-small);
+  font-weight: var(--t-weight-semi);
+  letter-spacing: 0.02em;
+  transition:
+    color var(--dur) var(--ease),
+    background var(--dur) var(--ease);
+}
+
+.contact-card__quick-actions a + a {
+  border-left: 1px solid var(--c-border);
+}
+
+.contact-card__quick-actions a:hover,
+.contact-card__quick-actions a:focus-visible {
+  color: var(--c-accent-teal);
+  background: color-mix(in srgb, var(--c-accent-teal) 7%, transparent);
+}
+
+.contact-card__quick-actions svg,
+.contact-card__detail-icon svg,
+.contact-card__footer svg {
+  width: 1.35rem;
+  height: 1.35rem;
+  fill: currentcolor;
+}
+
+.contact-card__details {
+  padding: var(--s-2) var(--s-5);
+}
+
+.contact-card__detail {
+  position: relative;
+  display: grid;
+  grid-template-columns: 2.5rem minmax(0, 1fr) auto;
+  gap: var(--s-3);
+  align-items: start;
+  padding: var(--s-5) 0;
+}
+
+.contact-card__detail + .contact-card__detail {
+  border-top: 1px solid var(--c-border);
+}
+
+.contact-card__detail-icon {
+  width: 2.5rem;
+  height: 2.5rem;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  color: var(--c-accent-teal);
+  background: color-mix(in srgb, var(--c-accent-teal) 9%, transparent);
+}
+
+.contact-card__label {
+  margin: 0 0 var(--s-1);
+  color: var(--fg-2);
+  font-family: var(--t-mono);
+  font-size: 0.7rem;
+  font-weight: var(--t-weight-semi);
+  letter-spacing: var(--t-track-wide);
+  text-transform: uppercase;
+}
+
+.contact-card__detail p {
+  margin: 0;
+}
+
+.contact-card__detail a:not(.contact-card__text-link) {
+  overflow-wrap: anywhere;
+  border-bottom-color: transparent;
+  color: var(--fg-strong);
+  font-weight: var(--t-weight-med);
+}
+
+.contact-card__detail a:hover {
+  color: var(--c-accent-teal);
+}
+
+.contact-card__secondary {
+  color: var(--fg-2);
+  font-size: var(--t-small);
+}
+
+.contact-card__text-link {
+  display: inline-block;
+  margin-top: var(--s-2);
+  border: 0;
+  color: var(--c-accent-teal);
+  font-size: var(--t-small);
+  font-weight: var(--t-weight-semi);
+}
+
+.contact-card__copy {
+  align-self: center;
+  padding: var(--s-2) var(--s-3);
+  border: 1px solid var(--c-border-strong);
+  border-radius: var(--r-pill);
+  color: var(--fg-2);
+  background: transparent;
+  font: 500 0.72rem/1 var(--t-mono);
+  cursor: pointer;
+  transition:
+    color var(--dur-fast) var(--ease),
+    border-color var(--dur-fast) var(--ease),
+    transform var(--dur-fast) var(--ease);
+}
+
+.contact-card__copy:hover,
+.contact-card__copy:focus-visible {
+  color: var(--c-accent-teal);
+  border-color: var(--c-accent-teal);
+  transform: translateY(-1px);
+}
+
+.contact-card__socials {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--s-2) var(--s-4);
+  margin-top: var(--s-3);
+}
+
+.contact-card__detail .contact-card__socials a {
+  color: var(--c-accent-teal);
+  font-family: var(--t-mono);
+  font-size: 0.74rem;
+  font-weight: var(--t-weight-med);
+}
+
+.contact-card__footer {
+  display: grid;
+  grid-template-columns: 1.35fr 1fr;
+  gap: var(--s-3);
+  padding: var(--s-5);
+  border-top: 1px solid var(--c-border);
+  background: var(--c-paper-tint);
+}
+
+.contact-card__save,
+.contact-card__share {
+  min-height: 3.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--s-2);
+  padding: 0 var(--s-4);
+  border-radius: var(--r-pill);
+  font: 600 var(--t-small) / 1 var(--t-sans);
+  cursor: pointer;
+  transition:
+    transform var(--dur) var(--ease),
+    box-shadow var(--dur) var(--ease),
+    background var(--dur) var(--ease);
+}
+
+.contact-card__save {
+  border: 1px solid var(--c-accent-teal);
+  color: var(--c-accent-teal-fg);
+  background: var(--c-accent-teal);
+  box-shadow: var(--shadow-md);
+}
+
+.contact-card__share {
+  border: 1px solid var(--c-border-strong);
+  color: var(--fg-strong);
+  background: var(--c-surface-strong);
+}
+
+.contact-card__save:hover,
+.contact-card__save:focus-visible,
+.contact-card__share:hover,
+.contact-card__share:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-soft);
+}
+
+.contact-card__save:hover,
+.contact-card__save:focus-visible {
+  border-bottom-color: var(--c-accent-teal);
+  color: var(--c-accent-teal-fg);
+  background: var(--c-accent-teal-hover);
+}
+
+.contact-card__status {
+  grid-column: 1 / -1;
+  min-height: 1rem;
+  margin: 0;
+  color: var(--fg-2);
+  font-size: 0.75rem;
+  text-align: center;
+}
+
+.contact-card__sheet > * {
+  animation: contact-card-reveal 600ms var(--ease) both;
+}
+
+.contact-card__sheet > :nth-child(2) {
+  animation-delay: 80ms;
+}
+
+.contact-card__sheet > :nth-child(3) {
+  animation-delay: 150ms;
+}
+
+.contact-card__sheet > :nth-child(4) {
+  animation-delay: 220ms;
+}
+
+@keyframes contact-card-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(1.2rem);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 35rem) {
+  .contact-card {
+    padding-inline: var(--s-2);
+  }
+
+  .contact-card__sheet {
+    border-radius: var(--r-md);
+  }
+
+  .contact-card__identity {
+    min-height: 28rem;
+    grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(12rem, 1fr) auto;
+    gap: var(--s-4);
+  }
+
+  .contact-card__portrait-wrap {
+    width: min(64%, 12rem);
+    justify-self: center;
+    border-radius: 8rem;
+    aspect-ratio: 1;
+    transform: rotate(-1deg);
+  }
+
+  .contact-card__heading {
+    padding-bottom: 0;
+    text-align: center;
+  }
+
+  .contact-card__heading .eyebrow,
+  .contact-card__role {
+    margin-inline: auto;
+  }
+
+  .contact-card__heading h1 {
+    font-size: clamp(2.75rem, 15vw, 4.25rem);
+  }
+
+  .contact-card__details {
+    padding-inline: var(--s-4);
+  }
+
+  .contact-card__detail {
+    grid-template-columns: 2.5rem minmax(0, 1fr);
+  }
+
+  .contact-card__copy {
+    grid-column: 2;
+    justify-self: start;
+    margin-top: var(--s-2);
+  }
+
+  .contact-card__footer {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .contact-card__sheet > *,
+  .contact-card__portrait-wrap,
+  .contact-card__save,
+  .contact-card__share {
+    animation: none;
+    transition: none;
+  }
+}

--- a/assets/css/contact-card.css
+++ b/assets/css/contact-card.css
@@ -16,7 +16,7 @@
   );
 }
 
-.contact-card-page .s-footer-v2 {
+.contact-card-page .c-footer {
   margin-top: 0;
 }
 

--- a/assets/js/contact-card.js
+++ b/assets/js/contact-card.js
@@ -1,0 +1,95 @@
+(function () {
+  "use strict";
+
+  const email = "vatsal.sanjay@durham.ac.uk";
+  const copyButton = document.querySelector("[data-copy-email]");
+  const shareButton = document.querySelector("[data-share-card]");
+  const status = document.querySelector("[data-card-status]");
+
+  const setStatus = (message) => {
+    if (!status) return;
+    status.textContent = message;
+    window.setTimeout(() => {
+      status.textContent = "";
+    }, 3000);
+  };
+
+  const copyWithExecCommand = (text) => {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.left = "-9999px";
+    document.body.appendChild(textarea);
+
+    try {
+      textarea.select();
+      return document.execCommand?.("copy") === true;
+    } finally {
+      textarea.remove();
+    }
+  };
+
+  const copyText = async (text) => {
+    if (copyWithExecCommand(text)) return;
+
+    if (navigator.clipboard?.writeText) {
+      await new Promise((resolve, reject) => {
+        const timer = window.setTimeout(
+          () => reject(new Error("Clipboard request timed out")),
+          800
+        );
+
+        navigator.clipboard.writeText(text).then(
+          () => {
+            window.clearTimeout(timer);
+            resolve();
+          },
+          (error) => {
+            window.clearTimeout(timer);
+            reject(error);
+          }
+        );
+      });
+      return;
+    }
+
+    throw new Error("Copy command unavailable");
+  };
+
+  copyButton?.addEventListener("click", async () => {
+    try {
+      await copyText(email);
+      copyButton.textContent = "Copied";
+      setStatus("Email address copied.");
+      window.setTimeout(() => {
+        copyButton.textContent = "Copy";
+      }, 2000);
+    } catch {
+      setStatus("Copy failed. Select the email address above.");
+    }
+  });
+
+  shareButton?.addEventListener("click", async () => {
+    const shareData = {
+      title: "Vatsal Sanjay · CoMPhy Lab",
+      text: "Contact details for Dr Vatsal Sanjay at Durham University.",
+      url: window.location.href,
+    };
+
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData);
+        setStatus("Contact card shared.");
+        return;
+      }
+
+      await copyText(shareData.url);
+      setStatus("Contact-card link copied.");
+    } catch (error) {
+      if (error?.name !== "AbortError") {
+        setStatus("Use your browser menu to share this page.");
+      }
+    }
+  });
+})();

--- a/assets/js/contact-card.js
+++ b/assets/js/contact-card.js
@@ -1,69 +1,36 @@
 (function () {
   "use strict";
 
-  const email = "vatsal.sanjay@durham.ac.uk";
   const copyButton = document.querySelector("[data-copy-email]");
   const shareButton = document.querySelector("[data-share-card]");
   const status = document.querySelector("[data-card-status]");
+  let copyResetTimeout;
+  let statusTimeout;
 
   const setStatus = (message) => {
     if (!status) return;
+    window.clearTimeout(statusTimeout);
     status.textContent = message;
-    window.setTimeout(() => {
+    statusTimeout = window.setTimeout(() => {
       status.textContent = "";
+      statusTimeout = undefined;
     }, 3000);
   };
 
-  const copyWithExecCommand = (text) => {
-    const textarea = document.createElement("textarea");
-    textarea.value = text;
-    textarea.setAttribute("readonly", "");
-    textarea.style.position = "fixed";
-    textarea.style.left = "-9999px";
-    document.body.appendChild(textarea);
-
-    try {
-      textarea.select();
-      return document.execCommand?.("copy") === true;
-    } finally {
-      textarea.remove();
-    }
-  };
-
-  const copyText = async (text) => {
-    if (copyWithExecCommand(text)) return;
-
-    if (navigator.clipboard?.writeText) {
-      await new Promise((resolve, reject) => {
-        const timer = window.setTimeout(
-          () => reject(new Error("Clipboard request timed out")),
-          800
-        );
-
-        navigator.clipboard.writeText(text).then(
-          () => {
-            window.clearTimeout(timer);
-            resolve();
-          },
-          (error) => {
-            window.clearTimeout(timer);
-            reject(error);
-          }
-        );
-      });
-      return;
-    }
-
-    throw new Error("Copy command unavailable");
+  const copyText = async (button, text) => {
+    const copied = await window.Utils?.copyToClipboard(button, text);
+    if (!copied) throw new Error("Copy command unavailable");
   };
 
   copyButton?.addEventListener("click", async () => {
     try {
-      await copyText(email);
+      await copyText(copyButton);
+      window.clearTimeout(copyResetTimeout);
       copyButton.textContent = "Copied";
       setStatus("Email address copied.");
-      window.setTimeout(() => {
+      copyResetTimeout = window.setTimeout(() => {
         copyButton.textContent = "Copy";
+        copyResetTimeout = undefined;
       }, 2000);
     } catch {
       setStatus("Copy failed. Select the email address above.");
@@ -72,9 +39,9 @@
 
   shareButton?.addEventListener("click", async () => {
     const shareData = {
-      title: "Vatsal Sanjay · CoMPhy Lab",
-      text: "Contact details for Dr Vatsal Sanjay at Durham University.",
-      url: window.location.href,
+      title: shareButton.dataset.shareTitle,
+      text: shareButton.dataset.shareText,
+      url: shareButton.dataset.shareUrl,
     };
 
     try {
@@ -84,7 +51,7 @@
         return;
       }
 
-      await copyText(shareData.url);
+      await copyText(shareButton, shareData.url);
       setStatus("Contact-card link copied.");
     } catch (error) {
       if (error?.name !== "AbortError") {

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -238,6 +238,7 @@ function createModal(options) {
  *
  * @param {HTMLElement} button - The button element that triggered the copy
  * @param {string} [text] - Text to copy (if not provided, uses button's data attributes)
+ * @returns {Promise<boolean>} Whether the text was copied successfully
  */
 function copyToClipboard(button, text) {
   const textToCopy =
@@ -247,25 +248,26 @@ function copyToClipboard(button, text) {
 
   if (!textToCopy) {
     console.warn("No text to copy");
-    return;
+    return Promise.resolve(false);
   }
 
   // Modern clipboard API
   if (navigator.clipboard && navigator.clipboard.writeText) {
-    navigator.clipboard
+    return navigator.clipboard
       .writeText(textToCopy)
       .then(() => {
         showCopyFeedback(button);
+        return true;
       })
       .catch((err) => {
         console.error("Copy failed:", err);
         // Fallback to older method
-        fallbackCopy(textToCopy, button);
+        return fallbackCopy(textToCopy, button);
       });
-  } else {
-    // Fallback for older browsers
-    fallbackCopy(textToCopy, button);
   }
+
+  // Fallback for older browsers
+  return Promise.resolve(fallbackCopy(textToCopy, button));
 }
 
 /**
@@ -274,6 +276,7 @@ function copyToClipboard(button, text) {
  * @private
  * @param {string} text - Text to copy
  * @param {HTMLElement} button - Button element for feedback
+ * @returns {boolean} Whether the text was copied successfully
  */
 function fallbackCopy(text, button) {
   const textarea = document.createElement("textarea");
@@ -285,10 +288,12 @@ function fallbackCopy(text, button) {
 
   try {
     textarea.select();
-    document.execCommand("copy");
-    showCopyFeedback(button);
+    const copied = document.execCommand("copy") === true;
+    if (copied) showCopyFeedback(button);
+    return copied;
   } catch (err) {
     console.error("Fallback copy failed:", err);
+    return false;
   } finally {
     document.body.removeChild(textarea);
   }

--- a/contact-card.html
+++ b/contact-card.html
@@ -90,6 +90,7 @@ body_class: contact-card-page
           class="contact-card__copy"
           type="button"
           data-copy-email
+          data-clipboard-text="vatsal.sanjay@durham.ac.uk"
           aria-label="Copy email address"
         >
           Copy
@@ -191,7 +192,14 @@ body_class: contact-card-page
         </svg>
         <span>Save contact</span>
       </a>
-      <button class="contact-card__share" type="button" data-share-card>
+      <button
+        class="contact-card__share"
+        type="button"
+        data-share-card
+        data-share-title="Vatsal Sanjay · CoMPhy Lab"
+        data-share-text="Contact details for Dr Vatsal Sanjay at Durham University."
+        data-share-url="{{ page.url | absolute_url }}"
+      >
         <svg aria-hidden="true" viewBox="0 0 24 24">
           <path
             d="M18 16a3 3 0 0 0-2.39 1.19l-6.7-3.35a3.1 3.1 0 0 0 0-1.68l6.7-3.35A3 3 0 1 0 15 7c0 .14.01.28.03.42L8.3 10.78a3 3 0 1 0 0 4.44l6.73 3.36A3 3 0 1 0 18 16Zm0-11.5A1.5 1.5 0 1 1 18 7.5a1.5 1.5 0 0 1 0-3ZM6 14.5a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3Zm12 6a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3Z"

--- a/contact-card.html
+++ b/contact-card.html
@@ -7,15 +7,6 @@ body_class: contact-card-page
 ---
 
 <main class="contact-card" aria-labelledby="contact-card-name">
-  <div
-    class="contact-card__glow contact-card__glow--one"
-    aria-hidden="true"
-  ></div>
-  <div
-    class="contact-card__glow contact-card__glow--two"
-    aria-hidden="true"
-  ></div>
-
   <article class="contact-card__sheet">
     <header class="contact-card__identity">
       <a class="contact-card__brand" href="/" aria-label="CoMPhy Lab home">

--- a/contact-card.html
+++ b/contact-card.html
@@ -1,0 +1,205 @@
+---
+layout: default
+title: "Vatsal Sanjay · Contact Card"
+description: "Save or share the contact details of Dr Vatsal Sanjay, principal investigator of the CoMPhy Lab at Durham University."
+permalink: /contact-card/
+body_class: contact-card-page
+---
+
+<main class="contact-card" aria-labelledby="contact-card-name">
+  <div
+    class="contact-card__glow contact-card__glow--one"
+    aria-hidden="true"
+  ></div>
+  <div
+    class="contact-card__glow contact-card__glow--two"
+    aria-hidden="true"
+  ></div>
+
+  <article class="contact-card__sheet">
+    <header class="contact-card__identity">
+      <a class="contact-card__brand" href="/" aria-label="CoMPhy Lab home">
+        <img src="/assets/logos/CoMPhy-Lab-no-name.png" alt="" />
+        <span>CoMPhy Lab</span>
+      </a>
+
+      <figure class="contact-card__portrait-wrap">
+        <img
+          class="contact-card__portrait"
+          src="/assets/images/team/0.jpg"
+          alt="Portrait of Dr Vatsal Sanjay"
+          width="1332"
+          height="1333"
+          fetchpriority="high"
+        />
+      </figure>
+
+      <div class="contact-card__heading">
+        <p class="eyebrow">Principal investigator</p>
+        <h1 id="contact-card-name">Vatsal Sanjay</h1>
+        <p class="contact-card__role">
+          Assistant Professor · Durham University
+        </p>
+      </div>
+    </header>
+
+    <nav class="contact-card__quick-actions" aria-label="Contact shortcuts">
+      <a
+        href="mailto:vatsal.sanjay@durham.ac.uk?subject=From%20your%20contact%20card"
+      >
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <path
+            d="M3 6.75A1.75 1.75 0 0 1 4.75 5h14.5A1.75 1.75 0 0 1 21 6.75v10.5A1.75 1.75 0 0 1 19.25 19H4.75A1.75 1.75 0 0 1 3 17.25V6.75Zm1.75-.25a.25.25 0 0 0-.25.25v.42l7.5 4.69 7.5-4.69v-.42a.25.25 0 0 0-.25-.25H4.75Zm14.75 2.44-7.1 4.44a.75.75 0 0 1-.8 0L4.5 8.94v8.31c0 .14.11.25.25.25h14.5a.25.25 0 0 0 .25-.25V8.94Z"
+          />
+        </svg>
+        <span>Email</span>
+      </a>
+      <a
+        href="https://www.google.com/maps/dir/?api=1&amp;destination=Rochester%20Building%2C%20Durham%20University%2C%20South%20Road%2C%20Durham%20DH1%203LE"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <path
+            d="M12 2a7 7 0 0 0-7 7c0 5.12 6.15 12.22 6.41 12.52a.8.8 0 0 0 1.18 0C12.85 21.22 19 14.12 19 9a7 7 0 0 0-7-7Zm0 18c-1.46-1.82-5.5-7.25-5.5-11a5.5 5.5 0 1 1 11 0c0 3.75-4.04 9.18-5.5 11Zm0-14a3 3 0 1 0 0 6 3 3 0 0 0 0-6Zm0 4.5a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3Z"
+          />
+        </svg>
+        <span>Directions</span>
+      </a>
+    </nav>
+
+    <div class="contact-card__details">
+      <section
+        class="contact-card__detail contact-card__detail--email"
+        aria-labelledby="contact-email-label"
+      >
+        <div class="contact-card__detail-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24">
+            <path
+              d="M3 6.75A1.75 1.75 0 0 1 4.75 5h14.5A1.75 1.75 0 0 1 21 6.75v10.5A1.75 1.75 0 0 1 19.25 19H4.75A1.75 1.75 0 0 1 3 17.25V6.75Zm1.75-.25a.25.25 0 0 0-.25.25v.42l7.5 4.69 7.5-4.69v-.42a.25.25 0 0 0-.25-.25H4.75Zm14.75 2.44-7.1 4.44a.75.75 0 0 1-.8 0L4.5 8.94v8.31c0 .14.11.25.25.25h14.5a.25.25 0 0 0 .25-.25V8.94Z"
+            />
+          </svg>
+        </div>
+        <div>
+          <p id="contact-email-label" class="contact-card__label">Email</p>
+          <a href="mailto:vatsal.sanjay@durham.ac.uk"
+            >vatsal.sanjay@durham.ac.uk</a
+          >
+        </div>
+        <button
+          class="contact-card__copy"
+          type="button"
+          data-copy-email
+          aria-label="Copy email address"
+        >
+          Copy
+        </button>
+      </section>
+
+      <section
+        class="contact-card__detail"
+        aria-labelledby="contact-affiliation-label"
+      >
+        <div class="contact-card__detail-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24">
+            <path
+              d="M3 21h18v-1.5h-1V8.1l1.35-.68a.75.75 0 0 0-.09-1.38l-9-4a.75.75 0 0 0-.52 0l-9 4a.75.75 0 0 0-.09 1.38L4 8.1v11.4H3V21Zm2.5-12.15 6.16 3.08a.75.75 0 0 0 .68 0l6.16-3.08V19.5h-2V13h-1.5v6.5h-2.25V13h-1.5v6.5H9V13H7.5v6.5h-2V8.85ZM12 3.55 19.15 6.7 12 10.27 4.85 6.7 12 3.55Z"
+            />
+          </svg>
+        </div>
+        <div>
+          <p id="contact-affiliation-label" class="contact-card__label">
+            Affiliation
+          </p>
+          <p>CoMPhy Lab · Department of Physics</p>
+          <p class="contact-card__secondary">Durham University</p>
+        </div>
+      </section>
+
+      <section
+        class="contact-card__detail"
+        aria-labelledby="contact-office-label"
+      >
+        <div class="contact-card__detail-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24">
+            <path
+              d="M12 2a7 7 0 0 0-7 7c0 5.12 6.15 12.22 6.41 12.52a.8.8 0 0 0 1.18 0C12.85 21.22 19 14.12 19 9a7 7 0 0 0-7-7Zm0 18c-1.46-1.82-5.5-7.25-5.5-11a5.5 5.5 0 1 1 11 0c0 3.75-4.04 9.18-5.5 11Zm0-14a3 3 0 1 0 0 6 3 3 0 0 0 0-6Zm0 4.5a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3Z"
+            />
+          </svg>
+        </div>
+        <div>
+          <p id="contact-office-label" class="contact-card__label">Office</p>
+          <p>Ph255, Wolfendale Wing, Rochester Building</p>
+          <p class="contact-card__secondary">
+            South Road, Durham DH1 3LE, United Kingdom
+          </p>
+          <a
+            class="contact-card__text-link"
+            href="https://www.google.com/maps/search/?api=1&amp;query=Rochester%20Building%2C%20Durham%20University%2C%20South%20Road%2C%20Durham%20DH1%203LE"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Show on map <span aria-hidden="true">↗</span></a
+          >
+        </div>
+      </section>
+
+      <section class="contact-card__detail" aria-labelledby="contact-web-label">
+        <div class="contact-card__detail-icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24">
+            <path
+              d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm6.9 6h-3.05a15.9 15.9 0 0 0-1.23-3.32A8.54 8.54 0 0 1 18.9 8ZM12 3.5c.83 0 1.96 1.65 2.31 4.5H9.69C10.04 5.15 11.17 3.5 12 3.5ZM9.38 4.68A15.9 15.9 0 0 0 8.15 8H5.1a8.54 8.54 0 0 1 4.28-3.32ZM4.56 9.5H8c-.04.5-.06 1-.06 1.5s.02 1 .06 1.5H4.56a8.55 8.55 0 0 1 0-3Zm.54 4.5h3.05c.25 1.28.67 2.4 1.23 3.32A8.54 8.54 0 0 1 5.1 14Zm6.9 6.5c-.83 0-1.96-1.65-2.31-4.5h4.62c-.35 2.85-1.48 4.5-2.31 4.5Zm2.46-6H9.54a18.3 18.3 0 0 1 0-5h4.92a18.3 18.3 0 0 1 0 5Zm.16 2.82A15.9 15.9 0 0 0 15.85 14h3.05a8.54 8.54 0 0 1-4.28 3.32Zm1.38-4.82c.04-.5.06-1 .06-1.5s-.02-1-.06-1.5h3.44a8.55 8.55 0 0 1 0 3H16Z"
+            />
+          </svg>
+        </div>
+        <div>
+          <p id="contact-web-label" class="contact-card__label">Online</p>
+          <a href="https://comphy-lab.org">comphy-lab.org</a>
+          <nav class="contact-card__socials" aria-label="Social profiles">
+            <a
+              href="https://github.com/comphy-lab"
+              target="_blank"
+              rel="noopener noreferrer"
+              >GitHub</a
+            >
+            <a
+              href="https://www.youtube.com/c/VatsalSanjay"
+              target="_blank"
+              rel="noopener noreferrer"
+              >YouTube</a
+            >
+            <a
+              href="https://www.linkedin.com/in/vatsalsanjay/"
+              target="_blank"
+              rel="noopener noreferrer"
+              >LinkedIn</a
+            >
+          </nav>
+        </div>
+      </section>
+    </div>
+
+    <footer class="contact-card__footer">
+      <a
+        class="contact-card__save"
+        href="/assets/contact/vatsal-sanjay.vcf"
+        download
+      >
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <path
+            d="M11.25 3v10.19L7.53 9.47 6.47 10.53 12 16.06l5.53-5.53-1.06-1.06-3.72 3.72V3h-1.5ZM4 18v3h16v-3h-1.5v1.5h-13V18H4Z"
+          />
+        </svg>
+        <span>Save contact</span>
+      </a>
+      <button class="contact-card__share" type="button" data-share-card>
+        <svg aria-hidden="true" viewBox="0 0 24 24">
+          <path
+            d="M18 16a3 3 0 0 0-2.39 1.19l-6.7-3.35a3.1 3.1 0 0 0 0-1.68l6.7-3.35A3 3 0 1 0 15 7c0 .14.01.28.03.42L8.3 10.78a3 3 0 1 0 0 4.44l6.73 3.36A3 3 0 1 0 18 16Zm0-11.5A1.5 1.5 0 1 1 18 7.5a1.5 1.5 0 0 1 0-3ZM6 14.5a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3Zm12 6a1.5 1.5 0 1 1 0-3 1.5 1.5 0 0 1 0 3Z"
+          />
+        </svg>
+        <span>Share page</span>
+      </button>
+      <p class="contact-card__status" aria-live="polite" data-card-status></p>
+    </footer>
+  </article>
+</main>

--- a/tests/contact-card.test.js
+++ b/tests/contact-card.test.js
@@ -1,0 +1,106 @@
+describe("contact card interactions", () => {
+  const flushAsync = async () => {
+    for (let step = 0; step < 6; step += 1) {
+      await Promise.resolve();
+    }
+  };
+
+  const loadCard = () => {
+    document.body.innerHTML = `
+      <button type="button" data-copy-email>Copy</button>
+      <button type="button" data-share-card>Share page</button>
+      <p data-card-status></p>
+    `;
+    jest.resetModules();
+    require("../assets/js/contact-card.js");
+  };
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    document.execCommand = undefined;
+    Object.defineProperty(navigator, "clipboard", {
+      value: undefined,
+      configurable: true,
+    });
+    Object.defineProperty(navigator, "share", {
+      value: undefined,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("copies the email address with the Clipboard API", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    loadCard();
+
+    document.querySelector("[data-copy-email]").click();
+    await flushAsync();
+
+    expect(writeText).toHaveBeenCalledWith("vatsal.sanjay@durham.ac.uk");
+    expect(document.querySelector("[data-copy-email]").textContent).toBe(
+      "Copied"
+    );
+    expect(document.querySelector("[data-card-status]").textContent).toBe(
+      "Email address copied."
+    );
+  });
+
+  it("falls back to execCommand without Clipboard API", async () => {
+    document.execCommand = jest.fn().mockReturnValue(true);
+    loadCard();
+
+    document.querySelector("[data-copy-email]").click();
+    await flushAsync();
+
+    expect(document.execCommand).toHaveBeenCalledWith("copy");
+    expect(document.querySelector("[data-card-status]").textContent).toBe(
+      "Email address copied."
+    );
+  });
+
+  it("uses native sharing when available", async () => {
+    const share = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "share", {
+      value: share,
+      configurable: true,
+    });
+    loadCard();
+
+    document.querySelector("[data-share-card]").click();
+    await flushAsync();
+
+    expect(share).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: "Vatsal Sanjay · CoMPhy Lab",
+        url: "http://localhost/",
+      })
+    );
+    expect(document.querySelector("[data-card-status]").textContent).toBe(
+      "Contact card shared."
+    );
+  });
+
+  it("copies the page URL when native sharing is unavailable", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    loadCard();
+
+    document.querySelector("[data-share-card]").click();
+    await flushAsync();
+
+    expect(writeText).toHaveBeenCalledWith("http://localhost/");
+    expect(document.querySelector("[data-card-status]").textContent).toBe(
+      "Contact-card link copied."
+    );
+  });
+});

--- a/tests/contact-card.test.js
+++ b/tests/contact-card.test.js
@@ -7,11 +7,22 @@ describe("contact card interactions", () => {
 
   const loadCard = () => {
     document.body.innerHTML = `
-      <button type="button" data-copy-email>Copy</button>
-      <button type="button" data-share-card>Share page</button>
+      <button
+        type="button"
+        data-copy-email
+        data-clipboard-text="vatsal.sanjay@durham.ac.uk"
+      >Copy</button>
+      <button
+        type="button"
+        data-share-card
+        data-share-title="Vatsal Sanjay · CoMPhy Lab"
+        data-share-text="Contact details for Dr Vatsal Sanjay."
+        data-share-url="https://comphy-lab.org/contact-card/"
+      >Share page</button>
       <p data-card-status></p>
     `;
     jest.resetModules();
+    require("../assets/js/utils.js");
     require("../assets/js/contact-card.js");
   };
 
@@ -79,7 +90,7 @@ describe("contact card interactions", () => {
     expect(share).toHaveBeenCalledWith(
       expect.objectContaining({
         title: "Vatsal Sanjay · CoMPhy Lab",
-        url: "http://localhost/",
+        url: "https://comphy-lab.org/contact-card/",
       })
     );
     expect(document.querySelector("[data-card-status]").textContent).toBe(
@@ -98,9 +109,62 @@ describe("contact card interactions", () => {
     document.querySelector("[data-share-card]").click();
     await flushAsync();
 
-    expect(writeText).toHaveBeenCalledWith("http://localhost/");
+    expect(writeText).toHaveBeenCalledWith(
+      "https://comphy-lab.org/contact-card/"
+    );
     expect(document.querySelector("[data-card-status]").textContent).toBe(
       "Contact-card link copied."
     );
+  });
+
+  it("waits for a delayed Clipboard API request", async () => {
+    let resolveClipboard;
+    const writeText = jest.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveClipboard = resolve;
+        })
+    );
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    loadCard();
+
+    document.querySelector("[data-copy-email]").click();
+    jest.advanceTimersByTime(800);
+    await flushAsync();
+
+    expect(document.querySelector("[data-card-status]").textContent).toBe("");
+
+    resolveClipboard();
+    await flushAsync();
+
+    expect(document.querySelector("[data-card-status]").textContent).toBe(
+      "Email address copied."
+    );
+  });
+
+  it("keeps the latest status visible for its full duration", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    loadCard();
+
+    document.querySelector("[data-copy-email]").click();
+    await flushAsync();
+    jest.advanceTimersByTime(1000);
+    document.querySelector("[data-share-card]").click();
+    await flushAsync();
+    jest.advanceTimersByTime(2000);
+
+    expect(document.querySelector("[data-card-status]").textContent).toBe(
+      "Contact-card link copied."
+    );
+
+    jest.advanceTimersByTime(1000);
+    expect(document.querySelector("[data-card-status]").textContent).toBe("");
   });
 });

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -149,13 +149,13 @@ describe("utils.js", () => {
         writable: true,
       });
 
-      window.Utils.copyToClipboard(button);
-      await Promise.resolve(); // flush microtasks
+      const copied = await window.Utils.copyToClipboard(button);
 
       expect(writeText).toHaveBeenCalledWith("hello world");
+      expect(copied).toBe(true);
     });
 
-    it("falls back to execCommand when navigator.clipboard is unavailable", () => {
+    it("falls back to execCommand when clipboard is unavailable", async () => {
       Object.defineProperty(navigator, "clipboard", {
         value: undefined,
         configurable: true,
@@ -170,9 +170,10 @@ describe("utils.js", () => {
         .spyOn(document, "execCommand")
         .mockReturnValue(true);
 
-      window.Utils.copyToClipboard(button);
+      const copied = await window.Utils.copyToClipboard(button);
 
       expect(execCommand).toHaveBeenCalledWith("copy");
+      expect(copied).toBe(true);
       execCommand.mockRestore();
     });
 
@@ -191,19 +192,19 @@ describe("utils.js", () => {
         .spyOn(document, "execCommand")
         .mockReturnValue(true);
 
-      window.Utils.copyToClipboard(button);
-      await Promise.resolve(); // let writeText reject
-      await Promise.resolve(); // let catch handler run
+      const copied = await window.Utils.copyToClipboard(button);
 
       expect(execCommand).toHaveBeenCalledWith("copy");
+      expect(copied).toBe(true);
       execCommand.mockRestore();
     });
 
-    it("does nothing if no text is available", () => {
+    it("reports failure if no text is available", async () => {
       const noTextBtn = document.createElement("button");
       document.body.appendChild(noTextBtn);
-      // Should not throw
-      expect(() => window.Utils.copyToClipboard(noTextBtn)).not.toThrow();
+      await expect(window.Utils.copyToClipboard(noTextBtn)).resolves.toBe(
+        false
+      );
     });
 
     it("reads text from data-clipboard-text attribute", () => {


### PR DESCRIPTION
## Summary
- Bring Vatsal Sanjay's conference contact card onto `comphy-lab.org`
- Replace the third-party QR landing page with a fast, accessible CoMPhy-owned surface

## Changes
- Add `/contact-card/` with email, directions, affiliation, office, website and social links
- Add a downloadable vCard plus native share and clipboard fallbacks
- Compose the page from the existing v2 design tokens with responsive light/dark styling and reduced-motion support
- Add focused interaction tests for clipboard and Web Share behaviour

## Testing
- `npm test -- --runInBand` — 81 tests passed
- `bundle exec jekyll build`
- `./scripts/validate-content-rules.sh`
- Prettier, ESLint, Stylelint and `git diff --check`
- Browser-checked at desktop and 390×844 mobile viewports