### PR TITLE
Guard missing contact-card clipboard helper

### DIFF
--- a/assets/js/contact-card.js
+++ b/assets/js/contact-card.js
@@ -18,7 +18,7 @@
   };
 
   const copyText = async (button, text) => {
-    const copied = await window.Utils?.copyToClipboard(button, text);
+    const copied = await window.Utils?.copyToClipboard?.(button, text);
     if (!copied) throw new Error("Copy command unavailable");
   };
 


### PR DESCRIPTION
## Summary
- Prevent the contact card from throwing before its existing copy-error handling when the shared clipboard helper is unavailable
- Address the concrete post-merge review finding on PR #101

## Changes
- Add optional chaining to the `copyToClipboard` method call in `assets/js/contact-card.js`
- Keep the existing fallback status message and control flow unchanged

## Testing
- `npm test -- --runInBand contact-card.test.js` (6 tests passed)
- `./scripts/lint-check.sh` (passed)
- `git diff --check` (passed)

## Evidence
- https://github.com/comphy-lab/comphy-lab.github.io/pull/101#discussion_r3602895033