### PR TITLE
Feature Worthington jets video on homepage

### DIFF
--- a/_data/hero.yml
+++ b/_data/hero.yml
@@ -30,18 +30,30 @@ cta_secondary:
   label: Join the lab
   href: /join
 
-# Hero rotator — three recent publications that sell the lab visually.
-# First is the visible default; others fade in every 6.5 s unless
-# prefers-reduced-motion is set.
+# Hero rotator — recent publications that sell the lab visually.
+# First is the visible default; slides fade every 6.5 s unless a
+# duration is set or prefers-reduced-motion is enabled.
 #
 # Each entry is EITHER:
 #   src: <image-path>       → rendered as an <img>
 #   youtube: <video-id>     → rendered as an embedded player, muted
 #                              autoplay loop, no controls
+#   youtube_end: <seconds>  → optionally stop/loop at this timestamp
+#   duration: <milliseconds> → optionally override the 6.5 s dwell
 #
 # caption_title + caption_sub float over a dark gradient at the
 # bottom of the panel.
 images:
+  - youtube: cCzpLutubF4
+    youtube_end: 20
+    duration: 20000
+    alt: >-
+      Self-similar Worthington jet emerging after the collapse of a
+      bubble cavity.
+    caption_title: Self-similar Worthington jets
+    caption_sub: Gordillo et al. · arXiv:2607.08972 (2026)
+    href: /research#self-similar-worthington-jets
+
   - video: https://www.dropbox.com/scl/fi/g82ozolz1ncub2s9my5oo/JMBC_Video.mp4?rlkey=6eooxf1rimh5e1r94mjpldp4w&dl=0
     type: video/mp4
     poster: /assets/images/news/jmbc-2026-best-video.jpg

--- a/_research/index.md
+++ b/_research/index.md
@@ -27,7 +27,7 @@ title: Research
 
 ## Work in Progress
 
-### Gordillo, J. M., Rodríguez-Rodríguez, J., & <strong>Sanjay, V.</strong> Self-similar Worthington jets. arXiv preprint arXiv:2607.08972 (2026).
+### Gordillo, J. M., Rodríguez-Rodríguez, J., & <strong>Sanjay, V.</strong> Self-similar Worthington jets. arXiv preprint arXiv:2607.08972 (2026). {#self-similar-worthington-jets}
 
 <div class="tags"><span>Bubbles</span><span>Jets</span><span>Soft-matter-singularities</span><span>Featured</span></div>
 
@@ -36,6 +36,8 @@ title: Research
 [![Blog](https://img.shields.io/badge/Blog-Coming%20Soon-yellow?style=flat-square&logo=obsidian&logoColor=white)](https://blogs.comphy-lab.org/0_ToDo-Blog-public)
 
 ![Self-similar collapse of a Worthington jet over more than two decades in dimensionless time](/assets/images/research/self-similar-worthington-jet-collapse.png){: width="75%" .center-block style="display: block; margin-left: auto; margin-right: auto;"}
+
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/cCzpLutubF4?rel=0" title="Self-similar Worthington jets — full video" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
 ### Ghaemi, A. H., Yang, Z., Huang, A., <strong>Sanjay, V.</strong>, Feng, J., & Constante-Amores, C. R. Bursting bubbles in Herschel-Bulkley fluids: dynamics and jetting transitions. arXiv preprint arXiv:2511.23345 (2025).
 

--- a/assets/css/research-v2.css
+++ b/assets/css/research-v2.css
@@ -375,6 +375,10 @@
 
 .research-content h2:first-of-type { margin-top: 0; }
 
+.research-content .paper-container {
+  scroll-margin-top: calc(80px + var(--s-5));
+}
+
 .research-content h3 {
   font-family: var(--t-serif);
   font-weight: 500;
@@ -384,6 +388,7 @@
   font-variation-settings: "opsz" 24;
   margin: var(--s-5) 0 var(--s-2);
   line-height: 1.35;
+  scroll-margin-top: calc(80px + var(--s-5));
 }
 
 .research-content strong { color: var(--c-accent-coral); font-weight: 600; }

--- a/index.html
+++ b/index.html
@@ -66,6 +66,7 @@ description: >-
           {% if img.video or img.youtube %}{% assign is_motion = true %}{% endif %}
           <figure class="hero__slide hero__slide--{% if is_motion %}motion{% else %}still{% endif %}"
                   data-active="{% if forloop.first %}true{% else %}false{% endif %}"
+                  data-duration="{{ img.duration | default: 6500 }}"
                   aria-hidden="{% if forloop.first %}false{% else %}true{% endif %}"
                   {% unless forloop.first %}inert{% endunless %}>
             <div class="hero__image-well">
@@ -77,7 +78,7 @@ description: >-
                 </video>
               {% elsif img.youtube %}
                 <iframe
-                  src="https://www.youtube-nocookie.com/embed/{{ img.youtube }}?autoplay=1&amp;mute=1&amp;loop=1&amp;playlist={{ img.youtube }}&amp;controls=0&amp;modestbranding=1&amp;rel=0&amp;playsinline=1&amp;iv_load_policy=3"
+                  src="https://www.youtube-nocookie.com/embed/{{ img.youtube }}?autoplay=1&amp;mute=1&amp;loop=1&amp;playlist={{ img.youtube }}&amp;controls=0&amp;modestbranding=1&amp;rel=0&amp;playsinline=1&amp;iv_load_policy=3{% if img.youtube_end %}&amp;end={{ img.youtube_end }}{% endif %}"
                   title="{{ img.alt }}"
                   frameborder="0"
                   allow="autoplay; encrypted-media; picture-in-picture"
@@ -295,12 +296,40 @@ description: >-
         v.removeAttribute('loop');
         try { v.pause(); v.currentTime = 0; } catch (e) {}
       });
+      media.querySelectorAll('iframe').forEach(function (frame) {
+        var src = frame.getAttribute('src') || '';
+        frame.setAttribute('src', src
+          .replace('autoplay=1', 'autoplay=0')
+          .replace('&loop=1', '&loop=0'));
+      });
       return;
     }
 
     if (figures.length < 2) return;
+    function resetMedia(figure) {
+      var video = figure.querySelector('video');
+      if (video) {
+        try {
+          video.currentTime = 0;
+          var playPromise = video.play();
+          if (playPromise) playPromise.catch(function () {});
+        } catch (e) {}
+      }
+
+      var frame = figure.querySelector('iframe');
+      if (frame) {
+        var src = frame.getAttribute('src');
+        frame.setAttribute('src', src);
+      }
+    }
+
+    function slideDuration(figure) {
+      var duration = parseInt(figure.getAttribute('data-duration'), 10);
+      return duration > 0 ? duration : 6500;
+    }
+
     var idx = 0;
-    setInterval(function () {
+    function advance() {
       figures[idx].setAttribute('data-active', 'false');
       figures[idx].setAttribute('aria-hidden', 'true');
       figures[idx].setAttribute('inert', '');
@@ -308,6 +337,10 @@ description: >-
       figures[idx].setAttribute('data-active', 'true');
       figures[idx].setAttribute('aria-hidden', 'false');
       figures[idx].removeAttribute('inert');
-    }, 6500);
+      resetMedia(figures[idx]);
+      setTimeout(advance, slideDuration(figures[idx]));
+    }
+
+    setTimeout(advance, slideDuration(figures[idx]));
   })();
 </script>


### PR DESCRIPTION
## Summary
- Feature the new Self-similar Worthington jets preprint in the homepage hero
- Embed the full research video with the paper while limiting the hero treatment to the first 20 seconds
- Preserve reduced-motion behaviour and clean mobile anchor navigation

## Changes
- Add the Worthington-jets YouTube slide and paper link to `_data/hero.yml`
- Support per-slide hero durations and optional YouTube end times
- Reset media when carousel slides reactivate and disable YouTube autoplay/loop for reduced motion
- Add the privacy-enhanced full-video embed and a stable paper anchor to the research entry
- Clear the fixed header when navigating directly to paper anchors

## Testing
- `npm test -- --runInBand` (83 tests passed)
- `npm run lint:css` (passed)
- `./scripts/lint-check.sh` (passed)
- `bash scripts/validate-content-rules.sh` (passed)
- `python3 scripts/check-content-rules-trigger-parity.py` (passed)
- `./scripts/build.sh` (passed)
- Desktop and mobile browser checks: no horizontal overflow; hero stayed active through 7 seconds and advanced after 20 seconds; reduced motion disabled autoplay and looping; the mobile paper anchor cleared the fixed header
- `git diff --check` (passed)
